### PR TITLE
nil objects will be sent when rbkit is unable to determine line number, ...

### DIFF
--- a/rbkit-lib/rbevents.cpp
+++ b/rbkit-lib/rbevents.cpp
@@ -48,7 +48,11 @@ static QVariantMap parseMsgpackObjectMap(msgpack::object_map obj)
         case msgpack::type::POSITIVE_INTEGER :
             map[keyStr] = (unsigned long long int)(val.via.u64);
             break;
+        case msgpack::type::NIL :
+            map[keyStr] = "";
+            break;
         default:
+            qDebug() << "throwing error while parsing event" << val.type;
             throw "unknown object type";
         }
 


### PR DESCRIPTION
...or when classname cannot be found
