### PR TITLE
Allow running rbkit from any directory.

### DIFF
--- a/tools/deployqt.rb
+++ b/tools/deployqt.rb
@@ -67,6 +67,8 @@ class DeployQt
 #!/bin/sh
 export LD_LIBRARY_PATH=\`pwd\`/libs
 export QT_QPA_FONTDIR=\`pwd\`/fonts
+
+cd "$(dirname "$0")"
 ./#{File.basename(executable)}
     EOD
     FileUtils.cp(executable, dst)


### PR DESCRIPTION
This change adds an explicit `cd` command to the directory containing the `rbkit` script.  Without it, `rbkit` must be run from the directory containing the wrapper script due its relative path to `RbkitClient`.  With the change, `rbkit` can be installed anywhere and run from any directory.